### PR TITLE
Using " starType : 'custom-icon' || starType: 'icon' " does not renders 'half star' content (possibly a typo in code)

### DIFF
--- a/src/star-rating.tpl.html
+++ b/src/star-rating.tpl.html
@@ -10,7 +10,7 @@
         ng-click="$ctrl.onStarClicked(star)">
 
         <i class="star-empty {{$ctrl.classEmpty}}"></i>
-        <i class="star-empty {{$ctrl.classHalf}}"></i>
+        <i class="star-half {{$ctrl.classHalf}}"></i>
         <i class="star-filled {{$ctrl.classFilled}}"></i>
 
         <svg class="star-empty {{$ctrl.classEmpty}}">


### PR DESCRIPTION
Using " starType : 'custom-icon' || starType: 'icon' " does not renders 'half star' content (possibly a typo in code), which is breaking 'css-star-rating' opacity based rendering as per rating value.